### PR TITLE
build: workflow to regenerate snapshot data (#57)

### DIFF
--- a/.github/workflows/regen-snapshot-data.yml
+++ b/.github/workflows/regen-snapshot-data.yml
@@ -1,0 +1,46 @@
+name: Regenerate snapshot data
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-run:
+    name: Regenerate on Ubuntu
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: checkout repo & submodules
+        uses: actions/checkout@v4
+
+      - name: install system packages
+        run: |
+          sudo apt -y update
+          sudo apt -y install libboost-dev
+
+      - name: install python dependencies
+        run: |
+          pip install --upgrade pip setuptools wheel
+          pip install cmake ninja
+
+      - name: install Threads with dev dependencies
+        run: |
+          pip install ".[dev]"
+
+      - name: display versions
+        run: |
+          python --version
+          pip list
+
+      - name: regenerate snapshot data
+        run: python test/regen_snapshot_data.py snapshot_out_dir
+
+      - name: Upload archive files
+        uses: actions/upload-artifact@v4
+        with:
+          name: regenerated-snapshot-data
+          path: |
+            snapshot_out_dir/expected_infer_snapshot.argn
+            snapshot_out_dir/expected_convert_snapshot.argn
+            snapshot_out_dir/expected_mapping_snapshot.mut
+            snapshot_out_dir/expected_imputed_snapshot.vcf
+

--- a/test/regen_snapshot_data.py
+++ b/test/regen_snapshot_data.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import threads_arg
+
+
+def regen_snapshot_files(out_dir: str):
+    """
+    Creates out_dir and re-runs all tests that require snapshot data.
+
+    This is intended to be run on CI so that snapshot tests are comparing data
+    generated on the same architecture. After triggering the tests, the snapshot
+    files may be downloaded as artifacts and re-committed.
+    """
+    os.mkdir(out_dir)
+
+    out_files = [
+        "expected_infer_snapshot.argn",
+        "expected_convert_snapshot.argn",
+        "expected_mapping_snapshot.mut",
+        "expected_imputed_snapshot.vcf"
+    ]
+
+    for out_file in out_files:
+        with open(f"{out_dir}/{out_file}", "wt") as f:
+            f.write(f"Dummy data for {out_file}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise RuntimeError("Specify output dir as first argument")
+
+    regen_snapshot_files(sys.argv[1])


### PR DESCRIPTION
- The regen script is in test/ because it will require access to the same files as the tests themselves.
- The script is presently just a stub that generates some mock artifacts to test the workflow. This is to make the action available in github UI for now so it can be tested on another branch.