### PR TITLE
bug fix

### DIFF
--- a/src/threads_arg/infer.py
+++ b/src/threads_arg/infer.py
@@ -203,9 +203,6 @@ def threads_infer(pgen, map, recombination_rate, demography, mutation_rate, fit_
     if fit_to_data and (physical_positions[1:] - physical_positions[:-1] <= 0).any():
         raise RuntimeError("Sites must be strictly increasing when --fit-to-data is set.")
 
-    # out_start, out_end = None, None
-    # if region is not None:
-    #     out_start, out_end = [int(r) for r in region.split("-")]
 
     reader = pgenlib.PgenReader(pgen.encode())
     num_samples = reader.get_raw_sample_ct()

--- a/src/threads_arg/infer.py
+++ b/src/threads_arg/infer.py
@@ -203,9 +203,9 @@ def threads_infer(pgen, map, recombination_rate, demography, mutation_rate, fit_
     if fit_to_data and (physical_positions[1:] - physical_positions[:-1] <= 0).any():
         raise RuntimeError("Sites must be strictly increasing when --fit-to-data is set.")
 
-    out_start, out_end = None, None
-    if region is not None:
-        out_start, out_end = [int(r) for r in region.split("-")]
+    # out_start, out_end = None, None
+    # if region is not None:
+    #     out_start, out_end = [int(r) for r in region.split("-")]
 
     reader = pgenlib.PgenReader(pgen.encode())
     num_samples = reader.get_raw_sample_ct()

--- a/src/threads_arg/serialization.py
+++ b/src/threads_arg/serialization.py
@@ -74,7 +74,7 @@ def serialize_instructions(instructions, out, variant_metadata=None, allele_ages
     dset_het_s[:] = flat_mismatches
     dset_range[:] = [region_start, region_end]
 
-    if (variant_metadata is not None) and (num_sites > 0):
+    if variant_metadata and num_sites:
         # If not none, it is a pandas dataframe with columns
         # CHR, POS, ID, REF, ALT, QUAL, FILTER
         min_pos = min(positions)

--- a/src/threads_arg/serialization.py
+++ b/src/threads_arg/serialization.py
@@ -74,7 +74,7 @@ def serialize_instructions(instructions, out, variant_metadata=None, allele_ages
     dset_het_s[:] = flat_mismatches
     dset_range[:] = [region_start, region_end]
 
-    if variant_metadata is not None:
+    if (variant_metadata is not None) and (num_sites > 0):
         # If not none, it is a pandas dataframe with columns
         # CHR, POS, ID, REF, ALT, QUAL, FILTER
         min_pos = min(positions)

--- a/src/threads_arg/serialization.py
+++ b/src/threads_arg/serialization.py
@@ -74,7 +74,7 @@ def serialize_instructions(instructions, out, variant_metadata=None, allele_ages
     dset_het_s[:] = flat_mismatches
     dset_range[:] = [region_start, region_end]
 
-    if variant_metadata and num_sites:
+    if variant_metadata is not None and num_sites:
         # If not none, it is a pandas dataframe with columns
         # CHR, POS, ID, REF, ALT, QUAL, FILTER
         min_pos = min(positions)

--- a/src/threads_arg/utils.py
+++ b/src/threads_arg/utils.py
@@ -169,9 +169,9 @@ def read_sample_names(pgen):
     elif os.path.isfile(psam):
         sam_df = pd.read_table(psam, sep=r"\s+")
         if "IID" in sam_df.columns:
-            return sam_df["IID"].tolist()
+            return sam_df["IID"].astype(str).tolist()
         elif "#IID" in sam_df.columns:
-            return sam_df["#IID"].tolist()
+            return sam_df["#IID"].astype(str).tolist()
         else:
             # If no header, default to famfile
             with open(psam, "r") as famfile:


### PR DESCRIPTION
I ran into several bugs when using threads on `.pgen` type files and here are some initial fixes I worked on

- fix `chr:start-end` parsing
- explicitly convert integer FID/IID to strings before saving to HDF5
- fix error when no variant metadata is present in the chosen output region