### PR TITLE
release v0.2.0 (#74)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/cpp
 {
-    "name": "TDPBWT",
+    "name": "threads",
 
     "build": {
         "dockerfile": "Dockerfile"

--- a/.github/workflows/pytest-ubuntu.yml
+++ b/.github/workflows/pytest-ubuntu.yml
@@ -46,7 +46,7 @@ jobs:
           pip install --upgrade pip setuptools wheel
           pip install cmake ninja
 
-      - name: install TDPBWT with dev dependencies
+      - name: install threads with dev dependencies
         run: |
           pip install ".[dev]"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 cmake_minimum_required(VERSION 3.16)
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
-project(threads_arg LANGUAGES CXX VERSION 0.1)
+project(threads_arg LANGUAGES CXX VERSION 0.2.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
-# 
+# Copyright (C) 2025 Threads Developers.
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ The user manual for threads can be found [here](https://palamaralab.github.io/so
 ## Rescomp user installation instructions
 
 Clone the threads-arg repo:
+
 ```sh
 git clone https://github.com/PalamaraLab/threads.git
 cd threads
 ```
 
 Load development modules:
+
 ```sh
 module load Python/3.11.3-GCCcore-12.3.0
 module load Boost/1.82.0-GCC-12.3.0
@@ -22,6 +24,7 @@ module load HDF5/1.14.0-gompi-2023a
 ```
 
 Create a new venv, activate and `pip install` to build:
+
 ```sh
 python -m venv venv
 . venv/bin/activate
@@ -30,6 +33,18 @@ pip install .
 ```
 
 For active development use `-e` and `[dev]` to for additional dependencies:
+
 ```sh
 pip install -e .[dev]
 ```
+
+## For developers: making a release
+
+- Bump the version number in [pyproject.toml](pyproject.toml), [CMakeLists.txt](CMakeLists.txt)
+- Update [RELEASE_NOTES.md](RELEASE_NOTES.md)
+- Push changes and check that all [GitHub workflows](https://github.com/PalamaraLab/threads/actions) pass
+- Tag the commit in Git using syntax `vX.Y.Z`
+- Make a release on GitHub, which should trigger a new build that will upload Python wheels to PyPI
+- If building wheels for a new Python version:
+  - Update classifiers in [pyproject.toml](pyproject.toml)
+  - Check whether version of `pypa/cibuildwheel` needs updating in [build-wheels.yml](.github/workflows/build-wheels.yml)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,7 +9,7 @@
 - Upgrade to numpy 2.0 (#39)
 - Consistent SHAPEIT format for regions (#42)
 - Ability to write impute output directly to stdout (#42)
-- Optimised allele age estimation (#51)
+- Allele age estimation and data consistency (#51)
 
 ### Fixed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,22 @@
-# Release notes
+# threads Release Notes
 
-Coming soon.
+## [0.2.0] - 2025-04-29
+
+### Added
+
+- Optimised imputation (#28)
+- Variant mapping (#38)
+- Upgrade to numpy 2.0 (#39)
+- Consistent SHAPEIT format for regions (#42)
+- Ability to write impute output directly to stdout (#42)
+- Optimised allele age estimation (#51)
+
+### Fixed
+
+- Fix os.sched_getaffinity macOS error (#49)
+
+## [0.1.0] - 2024-07-04
+
+### Added
+
+- Initial version of threads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,15 @@
 [build-system]
-requires = ["scikit-build-core>=0.9.5", "pybind11"]
+requires = [
+    "scikit-build-core>=0.10.5",
+    "pybind11"
+]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "threads-arg"
 version = "0.2.0"
+dynamic = ["readme"]
 description = "Highly scalable inference of ancestral recombination graphs (ARGs)"
-readme = "README_PyPI.md"
 authors = [
     { name = "Threads Developers" }
 ]
@@ -54,3 +57,13 @@ cmake.args = [
 ]
 cmake.verbose = true
 cmake.build-type = "Release"
+
+metadata.readme.provider = "scikit_build_core.metadata.fancy_pypi_readme"
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README_PyPI.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "RELEASE_NOTES.md"

--- a/src/AlleleAges.cpp
+++ b/src/AlleleAges.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/AlleleAges.cpp
+++ b/src/AlleleAges.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/AlleleAges.hpp
+++ b/src/AlleleAges.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/AlleleAges.hpp
+++ b/src/AlleleAges.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,16 +1,16 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
-# 
+# Copyright (C) 2025 Threads Developers.
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/DataConsistency.cpp
+++ b/src/DataConsistency.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/DataConsistency.cpp
+++ b/src/DataConsistency.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/DataConsistency.hpp
+++ b/src/DataConsistency.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/DataConsistency.hpp
+++ b/src/DataConsistency.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/Demography.cpp
+++ b/src/Demography.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Demography.cpp
+++ b/src/Demography.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/Demography.hpp
+++ b/src/Demography.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Demography.hpp
+++ b/src/Demography.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/GenotypeIterator.cpp
+++ b/src/GenotypeIterator.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/GenotypeIterator.cpp
+++ b/src/GenotypeIterator.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/GenotypeIterator.hpp
+++ b/src/GenotypeIterator.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/GenotypeIterator.hpp
+++ b/src/GenotypeIterator.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/HMM.cpp
+++ b/src/HMM.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/HMM.cpp
+++ b/src/HMM.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/HMM.hpp
+++ b/src/HMM.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/HMM.hpp
+++ b/src/HMM.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/ImputationMatcher.cpp
+++ b/src/ImputationMatcher.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ImputationMatcher.cpp
+++ b/src/ImputationMatcher.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/ImputationMatcher.hpp
+++ b/src/ImputationMatcher.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ImputationMatcher.hpp
+++ b/src/ImputationMatcher.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/Matcher.cpp
+++ b/src/Matcher.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Matcher.cpp
+++ b/src/Matcher.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/Matcher.hpp
+++ b/src/Matcher.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Matcher.hpp
+++ b/src/Matcher.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/State.hpp
+++ b/src/State.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/State.hpp
+++ b/src/State.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/ThreadingInstructions.cpp
+++ b/src/ThreadingInstructions.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ThreadingInstructions.cpp
+++ b/src/ThreadingInstructions.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/ThreadingInstructions.hpp
+++ b/src/ThreadingInstructions.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ThreadingInstructions.hpp
+++ b/src/ThreadingInstructions.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/ThreadsFastLS.cpp
+++ b/src/ThreadsFastLS.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ThreadsFastLS.cpp
+++ b/src/ThreadsFastLS.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
+// Copyright (C) 2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ThreadsFastLS.hpp
+++ b/src/ThreadsFastLS.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ThreadsFastLS.hpp
+++ b/src/ThreadsFastLS.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/ThreadsLowMem.cpp
+++ b/src/ThreadsLowMem.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ThreadsLowMem.cpp
+++ b/src/ThreadsLowMem.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/ThreadsLowMem.hpp
+++ b/src/ThreadsLowMem.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ThreadsLowMem.hpp
+++ b/src/ThreadsLowMem.hpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/VCFWriter.cpp
+++ b/src/VCFWriter.cpp
@@ -1,17 +1,17 @@
 
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/VCFWriter.cpp
+++ b/src/VCFWriter.cpp
@@ -1,6 +1,6 @@
 
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/VCFWriter.hpp
+++ b/src/VCFWriter.hpp
@@ -1,17 +1,17 @@
 
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/VCFWriter.hpp
+++ b/src/VCFWriter.hpp
@@ -1,6 +1,6 @@
 
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ViterbiLowMem.cpp
+++ b/src/ViterbiLowMem.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ViterbiLowMem.cpp
+++ b/src/ViterbiLowMem.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
+// Copyright (C) 2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ViterbiLowMem.hpp
+++ b/src/ViterbiLowMem.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ViterbiLowMem.hpp
+++ b/src/ViterbiLowMem.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
+// Copyright (C) 2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/pybind_utils.cpp
+++ b/src/pybind_utils.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/pybind_utils.hpp
+++ b/src/pybind_utils.hpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/__init__.py
+++ b/src/threads_arg/__init__.py
@@ -1,16 +1,16 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
-# 
+# Copyright (C) 2025 Threads Developers.
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/threads_arg/__init__.py
+++ b/src/threads_arg/__init__.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/__main__.py
+++ b/src/threads_arg/__main__.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/__main__.py
+++ b/src/threads_arg/__main__.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/allele_ages.py
+++ b/src/threads_arg/allele_ages.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/allele_ages.py
+++ b/src/threads_arg/allele_ages.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/convert.py
+++ b/src/threads_arg/convert.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/convert.py
+++ b/src/threads_arg/convert.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/infer.py
+++ b/src/threads_arg/infer.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/infer.py
+++ b/src/threads_arg/infer.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/map_mutations_to_arg.py
+++ b/src/threads_arg/map_mutations_to_arg.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/map_mutations_to_arg.py
+++ b/src/threads_arg/map_mutations_to_arg.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/phase.py
+++ b/src/threads_arg/phase.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/phase.py
+++ b/src/threads_arg/phase.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/serialization.py
+++ b/src/threads_arg/serialization.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/serialization.py
+++ b/src/threads_arg/serialization.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/utils.py
+++ b/src/threads_arg/utils.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg/utils.py
+++ b/src/threads_arg/utils.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/threads_arg_pybind.cpp
+++ b/src/threads_arg_pybind.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/threads_arg_pybind.cpp
+++ b/src/threads_arg_pybind.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,16 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
-# 
+# Copyright (C) 2025 Threads Developers.
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_data_snapshot.py
+++ b/test/test_data_snapshot.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_data_snapshot.py
+++ b/test/test_data_snapshot.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_demography.cpp
+++ b/test/test_demography.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/test/test_demography.cpp
+++ b/test/test_demography.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/test/test_impute_snapshot.py
+++ b/test/test_impute_snapshot.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_impute_snapshot.py
+++ b/test/test_impute_snapshot.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_instructions.py
+++ b/test/test_instructions.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_instructions.py
+++ b/test/test_instructions.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2024 Threads Developers.
+# Copyright (C) 2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,5 +1,5 @@
 # This file is part of the Threads software suite.
-# Copyright (C) 2025 Threads Developers.
+# Copyright (C) 2024-2025 Threads Developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/test_viterbi_state.cpp
+++ b/test/test_viterbi_state.cpp
@@ -1,5 +1,5 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2025 Threads Developers.
+// Copyright (C) 2024-2025 Threads Developers.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/test/test_viterbi_state.cpp
+++ b/test/test_viterbi_state.cpp
@@ -1,16 +1,16 @@
 // This file is part of the Threads software suite.
-// Copyright (C) 2024 Threads Developers.
-// 
+// Copyright (C) 2025 Threads Developers.
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 


### PR DESCRIPTION
Branch to tidy prior to release

- Update copyrights to 2025.
- Bump CMake version to 0.2.0
- Note the pyproject bump to 0.2.0 was previously pushed in rev be539ea9 (ci: simplify workflows for public repo (#74))
- Add release notes (using https://keepachangelog.com/en/1.1.0/ format)
- Add fancy-pypi-readme (as in arg-needle-lib) to append release notes to PyPI page
- Rename a few remaining references to "TDPBWT" to "threads"