### PR TITLE
build: add ubuntu-24.04-arm to wheels build (#82)

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -46,6 +46,7 @@ jobs:
       CIBW_SKIP: cp3*-musllinux_*
       CIBW_ARCHS: ${{ matrix.arch }}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+      CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
       CIBW_BEFORE_ALL: ${{ matrix.before-all }}
       CIBW_BEFORE_BUILD: pip install --upgrade pip setuptools wheel
       CIBW_ENVIRONMENT: ${{ matrix.extra-env }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -23,7 +23,12 @@ jobs:
           - os: ubuntu-24.04
             arch: auto64
             py-vers: cp39-* cp310-* cp311-* cp312-* cp313-*
-            before-all: yum -y install cmake ninja-build boost-devel
+            before-all: dnf -y install cmake ninja-build boost-devel
+            extra-env: ""
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+            py-vers: cp39-* cp310-* cp311-* cp312-* cp313-*
+            before-all: dnf -y install cmake ninja-build boost-devel
             extra-env: ""
           - os: macos-13
             arch: x86_64


### PR DESCRIPTION
- Copied from latest arg-needle-lib; will allow docker/podman containers to work with threads on macos.
- Replaced old `yum` command with modern equivalent `dnf`.